### PR TITLE
Add glama.json for MCP registry listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "nicofains1"
+  ]
+}


### PR DESCRIPTION
Adds glama.json metadata file to trigger auto-indexing by the Glama MCP server registry.

Glama (19,400+ MCP servers indexed) requires this file to discover and list MCP servers. The awesome-mcp-servers PR #3264 was closed with a `missing-glama` label, making this a prerequisite for that listing too.

The file declares the maintainer per the Glama schema spec.